### PR TITLE
"Fix" for hidden URL input text when suggestions appear

### DIFF
--- a/firefox/mono-firefox-theme/theme/parts/urlbar.css
+++ b/firefox/mono-firefox-theme/theme/parts/urlbar.css
@@ -7,10 +7,6 @@
     --urlbar-toolbar-height: 34.00px !important;
 }
 
-#urlbar-container {
-    --urlbar-container-height: 0 !important;
-}
-
 /* Center the URL bar */
 toolbarspring {
     max-width: 10000px !important;


### PR DESCRIPTION
Tested in Firefox 128. I had this issue for a while, no idea when did it start.

This reverts a change made in the commit 65f500d.